### PR TITLE
added mixer.init to avoid error

### DIFF
--- a/src/audio_player.py
+++ b/src/audio_player.py
@@ -146,6 +146,7 @@ class AudioPlayer(QObject):
                 self._set_max_progress_bar()
             mixer.music.play()
         else:
+            mixer.init()
             mixer.music.unpause()
             self._paused = False
         self._timer.start(self._TIME_STEP)


### PR DESCRIPTION
Error LOG : 
Traceback (most recent call last):
  File "/home/XXXXX/Artemis/src/audio_player.py", line 106, in _update_bar
    pos = mixer.music.get_pos()
pygame.error: mixer not initialized
Abandon