### PR TITLE
Fix crash for playing audio

### DIFF
--- a/src/audio_player.py
+++ b/src/audio_player.py
@@ -1,3 +1,4 @@
+import math
 import os
 from pygame import mixer
 from PyQt5.QtCore import QTimer, pyqtSlot, QObject
@@ -120,7 +121,7 @@ class AudioPlayer(QObject):
     def _set_max_progress_bar(self):
         """Set the maximum value of the progress bar."""
         self._audio_progress.setMaximum(
-            mixer.Sound(self._audio_file).get_length() * 1000
+            math.ceil(mixer.Sound(self._audio_file).get_length() * 1000)
         )
 
     def set_audio_player(self, fname=""):


### PR DESCRIPTION
pygame 2.1.2 (SDL 2.24.0, Python 3.10.7
  File "audio_player.py", line 122, in _set_max_progress_bar
    self._audio_progress.setMaximum(
TypeError: setMaximum(self, int): argument 1 has unexpected type 'float'